### PR TITLE
Add OnCue XML export feature

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -157,18 +157,39 @@ async def transcribe(
                 create_docx = transcriber.create_docx
         
         docx_bytes = create_docx(title_data, turns, timestamps_enabled)
+        try:
+            from .transcriber import create_oncue_xml
+        except ImportError:
+            try:
+                from transcriber import create_oncue_xml
+            except ImportError:
+                import transcriber
+                create_oncue_xml = transcriber.create_oncue_xml
+
+        xml_bytes = create_oncue_xml(title_data, turns, timestamps_enabled)
         logger.info(f"Used cached transcription with {len(turns)} turns.")
     else:
         # Generate new transcription
         logger.info(f"Starting new transcription process with model: {ai_model}...")
         try:
-            result = process_transcription(file_bytes, file.filename, speaker_list, title_data, timestamps_enabled, ai_model, force_timestamps_for_subtitles=True)
-            if len(result) == 4:
+            result = process_transcription(
+                file_bytes,
+                file.filename,
+                speaker_list,
+                title_data,
+                timestamps_enabled,
+                ai_model,
+                force_timestamps_for_subtitles=True,
+            )
+            if len(result) == 5:
+                turns, docx_bytes, srt_content, webvtt_content, xml_bytes = result
+            elif len(result) == 4:
                 turns, docx_bytes, srt_content, webvtt_content = result
+                xml_bytes = None
             else:
                 # Backward compatibility for old version
                 turns, docx_bytes = result
-                srt_content, webvtt_content = None, None
+                srt_content, webvtt_content, xml_bytes = None, None, None
                 
             # Cache the transcript results (not the docx, as that depends on timestamp setting)
             temp_transcript_cache[cache_key] = {
@@ -189,11 +210,13 @@ async def transcribe(
     else:
         transcript_text = "\n\n".join([f"{t.speaker.upper()}:\t\t{t.text}" for t in turns])
     encoded = base64.b64encode(docx_bytes).decode()
+    xml_encoded = base64.b64encode(xml_bytes).decode() if xml_bytes else None
     
     response_data = {
         "transcript": transcript_text, 
         "docx_base64": encoded,
-        "has_subtitles": srt_content is not None
+        "has_subtitles": srt_content is not None,
+        "oncue_xml_base64": xml_encoded
     }
     
     # Include subtitles if available
@@ -295,19 +318,20 @@ async def generate_subtitles_preview(
     try:
         # Process with timestamps enabled
         result = process_transcription(
-            file_data['content'], 
-            file_data['filename'], 
-            speaker_list, 
-            title_data, 
+            file_data['content'],
+            file_data['filename'],
+            speaker_list,
+            title_data,
             include_timestamps=True,  # Always include timestamps for subtitles
             ai_model=ai_model
         )
-        
-        if len(result) == 4:
-            turns, _, srt_content, webvtt_content = result
+
+        if len(result) >= 4:
+            turns = result[0]
+            srt_content = result[2]
+            webvtt_content = result[3]
         else:
-            # Fallback if subtitles not generated
-            turns, _ = result
+            turns = result[0]
             srt_content, webvtt_content = None, None
         
         if not srt_content:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -613,6 +613,9 @@
                     <a id="downloadSrt" class="download-btn" style="display:none; background: #6c757d;">
                         🎬 Download Subtitles (SRT)
                     </a>
+                    <a id="downloadXml" class="download-btn" style="display:none; background: #28a745;">
+                        📁 Download OnCue XML
+                    </a>
                 </div>
                 <pre id="transcript" class="transcript-output"></pre>
             </div>
@@ -961,6 +964,7 @@
                 // Setup download links
                 const link = document.getElementById('download');
                 const srtLink = document.getElementById('downloadSrt');
+                const xmlLink = document.getElementById('downloadXml');
                 
                 link.href = 'data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,' + result.docx_base64;
                 
@@ -980,6 +984,14 @@
                     srtLink.style.display = 'inline-flex';
                 } else {
                     srtLink.style.display = 'none';
+                }
+
+                if (result.oncue_xml_base64) {
+                    xmlLink.href = 'data:text/xml;base64,' + result.oncue_xml_base64;
+                    xmlLink.download = baseFilename + '.xml';
+                    xmlLink.style.display = 'inline-flex';
+                } else {
+                    xmlLink.style.display = 'none';
                 }
                 
                 // Scroll to results


### PR DESCRIPTION
## Summary
- create new `create_oncue_xml` helper in `transcriber.py`
- generate OnCue XML in `process_transcription`
- expose XML bytes via `/api/transcribe`
- regenerate XML when serving cached transcripts
- add download button in UI for OnCue XML file

## Testing
- `python -m py_compile backend/transcriber.py backend/server.py`
- *(failure: `ModuleNotFoundError` when attempting runtime test)*

------
https://chatgpt.com/codex/tasks/task_e_685a1551edb483208f2682604601ff8d